### PR TITLE
Fix setting arguments in constructor

### DIFF
--- a/src/Token/Block.php
+++ b/src/Token/Block.php
@@ -77,7 +77,10 @@ class Block extends BaseToken implements \IteratorAggregate, \ArrayAccess, \Coun
         }
 
         if ($argument !== null) {
-            $this->argument = $argument;
+            if (!is_array($argument)) {
+                $argument = array($argument);
+            }
+            $this->arguments = $argument;
         }
     }
 


### PR DESCRIPTION
Fixed typo and made sure that `$argument` is an array as defined in the class definition.