### PR TITLE
Use fnmatch to allow wildcard searches

### DIFF
--- a/src/HtaccessContainer.php
+++ b/src/HtaccessContainer.php
@@ -131,7 +131,7 @@ class HtaccessContainer extends BaseArrayObject implements HtaccessInterface
         $array = $this->getArrayCopy();
 
         foreach ($array as $token) {
-            if ($token->getName() === $name) {
+            if (fnmatch($name, $token->getName())) {
                 if ($type === null) {
                     return $token;
                 }
@@ -151,7 +151,7 @@ class HtaccessContainer extends BaseArrayObject implements HtaccessInterface
     private function deepSearch(Block $parent, $name, $type)
     {
         foreach ($parent as $token) {
-            if ($token->getName() === $name) {
+            if (fnmatch($name, $token->getName())) {
                 if ($type === null) {
                     return $token;
                 }


### PR DESCRIPTION
This allows searches for directives like `suphp_*` and others.
See http://php.net/fnmatch for more details.