### PR TITLE
Throw SyntaxException on syntax error

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -265,8 +265,8 @@ class Parser
             return $this->parseBlockLine($line, $file, $lineBreaks);
         }
 
-        //We might try to throw new SyntaxException($file->key(), $line, "Unexpected line") in the future
-        return null;
+        //Syntax not recognized so we throw SyntaxException
+        throw new SyntaxException($file->key(), $line, "Unexpected line")
     }
 
     /**

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -266,7 +266,7 @@ class Parser
         }
 
         //Syntax not recognized so we throw SyntaxException
-        throw new SyntaxException($file->key(), $line, "Unexpected line")
+        throw new SyntaxException($file->key(), $line, "Unexpected line");
     }
 
     /**


### PR DESCRIPTION
The parser currently skips faulty lines but should throw an exception instead.

Closes #8