### PR TITLE
Fix case insensitive Block names and Add token type while converting to array

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -342,7 +342,7 @@ class Parser
         $line = trim($line);
         $pattern = '/^\<\/';
         $pattern .= ($blockName) ? $blockName : '[^\s\>]+';
-        $pattern .= '\>$/';
+        $pattern .= '\>$/i';
         return (preg_match($pattern, $line) > 0);
     }
 

--- a/src/Token/Block.php
+++ b/src/Token/Block.php
@@ -418,6 +418,7 @@ class Block extends BaseToken implements \IteratorAggregate, \ArrayAccess, \Coun
     public function toArray()
     {
         $array = [
+            'type'      => $this->getTokenType(),
             'name'      => $this->getName(),
             'arguments' => $this->getArguments(),
             'children'  => array()

--- a/src/Token/Comment.php
+++ b/src/Token/Comment.php
@@ -133,7 +133,10 @@ class Comment extends BaseToken
      */
     public function toArray()
     {
-        return array('comment' => $this->text);
+        return [
+            'type'    => $this->getTokenType(),
+            'comment' => $this->text
+        ]
     }
 
     /**

--- a/src/Token/Comment.php
+++ b/src/Token/Comment.php
@@ -136,7 +136,7 @@ class Comment extends BaseToken
         return [
             'type'    => $this->getTokenType(),
             'comment' => $this->text
-        ]
+        ];
     }
 
     /**

--- a/src/Token/Directive.php
+++ b/src/Token/Directive.php
@@ -200,6 +200,7 @@ class Directive extends BaseToken
     public function toArray()
     {
         return [
+            'type'      => $this->getTokenType(),
             'name'      => $this->getName(),
             'arguments' => $this->getArguments()
         ];

--- a/src/Token/WhiteLine.php
+++ b/src/Token/WhiteLine.php
@@ -82,7 +82,7 @@ class WhiteLine extends BaseToken
         return [
             'type'      => $this->getTokenType(),
             'WhiteLine' => ''
-        ]
+        ];
     }
 
     /**

--- a/src/Token/WhiteLine.php
+++ b/src/Token/WhiteLine.php
@@ -79,7 +79,10 @@ class WhiteLine extends BaseToken
      */
     public function toArray()
     {
-        return array('WhiteLine' => '');
+        return [
+            'type'      => $this->getTokenType(),
+            'WhiteLine' => ''
+        ]
     }
 
     /**


### PR DESCRIPTION
When converting a token to array, we should add the token type as well. This will provide a proper way of differentiating between tokens once they are converted to array.