### PR TITLE
fix: Implicitly marked parameters as nullable is deprecated in PHP 8.4

### DIFF
--- a/src/HtaccessContainer.php
+++ b/src/HtaccessContainer.php
@@ -120,7 +120,7 @@ class HtaccessContainer extends BaseArrayObject implements HtaccessInterface
      * @param bool $deepSearch [optional] If the search should be multidimensional. Default is true
      * @return null|TokenInterface Returns the Token or null if none is found
      */
-    public function search(string $name, int $type = null, bool $deepSearch = true): ?TokenInterface
+    public function search(string $name, ?int $type = null, bool $deepSearch = true): ?TokenInterface
     {
         /** @var TokenInterface[] $array */
         $array = $this->getArrayCopy();
@@ -171,13 +171,13 @@ class HtaccessContainer extends BaseArrayObject implements HtaccessInterface
     }
 
     /**
-     * Search this object for a Token with specific name and return the index(key) of the first match
+     * Search this object for a Token with a specific name and return the index(key) of the first match
      *
      * @param string $name [required] Name of the token
      * @param int|null $type [optional] TOKEN_DIRECTIVE | TOKEN_BLOCK
      * @return int|null Returns the index or null if Token is not found
      */
-    public function getIndex(string $name, int $type = null): ?int
+    public function getIndex(string $name, ?int $type = null): ?int
     {
         /** @var TokenInterface[] $array */
         $array = $this->getArrayCopy();
@@ -227,7 +227,7 @@ class HtaccessContainer extends BaseArrayObject implements HtaccessInterface
      * @return string
      *@api
      */
-    public function txtSerialize(int $indentation = null, bool $ignoreWhiteLines = null, bool $ignoreComments = false): string
+    public function txtSerialize(?int $indentation = null, ?bool $ignoreWhiteLines = null, bool $ignoreComments = false): string
     {
         /** @var TokenInterface[] $array */
         $array = $this->getArrayCopy();
@@ -363,7 +363,7 @@ class HtaccessContainer extends BaseArrayObject implements HtaccessInterface
      *
      * @return array                 Returns the array consisting of the extracted elements.
      */
-    public function splice(int $offset, int $length = null, ArrayAccess|array $replacement = array()): array
+    public function splice(int $offset, ?int $length = null, ArrayAccess|array $replacement = array()): array
     {
         $array = $this->getArrayCopy();
         $spliced = array_splice($array, $offset, $length, $replacement);

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -186,7 +186,7 @@ class Parser
      * @throws SyntaxException
      * @api
      */
-    public function parse(SplFileObject $file = null, int|null $optFlags = null, bool|null $rewind = null): HtaccessContainer|ArrayAccess|array
+    public function parse(?SplFileObject $file = null, int|null $optFlags = null, bool|null $rewind = null): HtaccessContainer|ArrayAccess|array
     {
         //Prepare passed options
         $file = ($file !== null) ? $file : $this->file;
@@ -347,7 +347,7 @@ class Parser
      * @param string|null $blockName [optional] The block's name
      * @return bool
      */
-    protected function isBlockEnd(string $line, string $blockName = null): bool
+    protected function isBlockEnd(string $line, ?string $blockName = null): bool
     {
         $line = trim($line);
         $pattern = '/^\<\/';

--- a/src/Token/Block.php
+++ b/src/Token/Block.php
@@ -70,7 +70,7 @@ class Block extends BaseToken implements IteratorAggregate, ArrayAccess, Countab
      * @param string $blockName [optional] The name of the block
      * @param string|null $argument [optional] The argument of the block
      */
-    public function __construct(string $blockName = 'blockName', string $argument = null)
+    public function __construct(string $blockName = 'blockName', ?string $argument = null)
     {
         $this->setName($blockName);
 


### PR DESCRIPTION
This fix avoids deprecation warnings with PHP 8.4